### PR TITLE
feat(map): Add disable cluster layer functionality for related pois oc: 3803

### DIFF
--- a/src/app/pages/map/map.page.html
+++ b/src/app/pages/map/map.page.html
@@ -102,6 +102,7 @@
     wmMapTrackRelatedPois
     (related-poi)="setCurrentRelatedPoi($event)"
     (related-poi-next)="currentPoiNextID$.next(+$event)"
+    [wmMapReletedPoisDisableClusterLayer]="(drawTrackEnable$|async)||(!(togglePoisDirective$|async) && (currentLayer$|async)==null)"
   >
     <wm-filters
       top-right


### PR DESCRIPTION
feat(map): Add disable cluster layer functionality for related pois

This commit adds the `[wmMapReletedPoisDisableClusterLayer]` attribute to the map page HTML template. The attribute is bound to a condition that disables the cluster layer for related pois when certain conditions are met. This feature enhances the user experience by providing more control over the display of related pois on the map.

WIP on develop
