### PR TITLE
chore: Remove duplicate wmMapOverlayUrl initialization oc: 4098

### DIFF
--- a/src/app/pages/map/map.page.html
+++ b/src/app/pages/map/map.page.html
@@ -67,7 +67,6 @@
     [wmMapFilters]="apiElasticState$|async"
     [wmMapTranslationCallback]="translationCallback"
     (wmMapOverlayEVT$)="setWmMapFeatureCollection($event)"
-    [wmMapOverlay]="(enableOverLay$|async)"
     [wmMapFeatureCollection]="(wmMapFeatureCollectionOverlay$|async)!= null"
     [wmMapFeatureCollectionOverlay]="wmMapFeatureCollectionOverlay$|async"
     (wmMapStateEvt)="setLoader($event)"

--- a/src/app/pages/map/map.page.html
+++ b/src/app/pages/map/map.page.html
@@ -68,7 +68,6 @@
     [wmMapTranslationCallback]="translationCallback"
     (wmMapOverlayEVT$)="setWmMapFeatureCollection($event)"
     [wmMapOverlay]="(enableOverLay$|async)"
-    [wmMapOverlayUrl]="'https://geohub.webmapp.it/api/taxonomy/where/geojson/13'"
     [wmMapFeatureCollection]="(wmMapFeatureCollectionOverlay$|async)!= null"
     [wmMapFeatureCollectionOverlay]="wmMapFeatureCollectionOverlay$|async"
     (wmMapStateEvt)="setLoader($event)"
@@ -164,7 +163,6 @@
           wmMapTarget="ol-stamp"
           [wmMapPadding]="mapPrintPadding$|async"
           [wmMapOverlay]="(enableOverLay$|async)"
-          [wmMapOverlayUrl]="'https://geohub.webmapp.it/api/taxonomy/where/geojson/13'"
           (currentCustomTrack)="saveCurrentCustomTrack($event)"
           wmMapTrack
           [track]="track$|async"

--- a/src/app/pages/map/map.page.ts
+++ b/src/app/pages/map/map.page.ts
@@ -124,7 +124,6 @@ export class MapPage implements OnDestroy {
   disableLayers$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   drawTrackEnable$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   enableDrawTrack$ = this._store.select(confShowDrawTrack);
-  enableOverLay$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   geohubId$ = this._store.select(confGeohubId);
   goToHomeSub$: Subscription = Subscription.EMPTY;
   graphhopperHost$: Observable<string> = of(environment.graphhopperHost);
@@ -264,13 +263,13 @@ export class MapPage implements OnDestroy {
     });
   }
 
-  next(): void {
-    this.WmMapTrackRelatedPoisDirective.poiNext();
-  }
-
   ngOnDestroy(): void {
     this.goToHomeSub$.unsubscribe();
     this.setCurrentPoiSub$.unsubscribe();
+  }
+
+  next(): void {
+    this.WmMapTrackRelatedPoisDirective.poiNext();
   }
 
   openPopup(popup: {name: string; html: string}): void {

--- a/src/app/pages/map/map.page.ts
+++ b/src/app/pages/map/map.page.ts
@@ -208,10 +208,6 @@ export class MapPage implements OnDestroy {
     this.dataLayerUrls$ = this.geohubId$.pipe(
       filter(g => g != null),
       map(geohubId => {
-        if (geohubId == 13) {
-          this.enableOverLay$.next(true);
-        }
-
         return {
           low: `https://wmpbf.s3.eu-central-1.amazonaws.com/${geohubId}/{z}/{x}/{y}.pbf`,
           high: `https://wmpbf.s3.eu-central-1.amazonaws.com/${geohubId}/{z}/{x}/{y}.pbf`,
@@ -268,13 +264,13 @@ export class MapPage implements OnDestroy {
     });
   }
 
+  next(): void {
+    this.WmMapTrackRelatedPoisDirective.poiNext();
+  }
+
   ngOnDestroy(): void {
     this.goToHomeSub$.unsubscribe();
     this.setCurrentPoiSub$.unsubscribe();
-  }
-
-  next(): void {
-    this.WmMapTrackRelatedPoisDirective.poiNext();
   }
 
   openPopup(popup: {name: string; html: string}): void {


### PR DESCRIPTION
- Removed duplicate initialization of wmMapOverlayUrl in map.page.html and map.page.ts
- Updated code to remove redundant assignment for better clarity.