### PR TITLE
chore: Update drawTrackComponent oc: 4438

### DIFF
--- a/src/app/components/draw-track/draw-track/draw-track.component.ts
+++ b/src/app/components/draw-track/draw-track/draw-track.component.ts
@@ -102,7 +102,7 @@ export class DrawTrackComponent {
   }
 
   editCustomTrackName(savedTrack: any): void {
-    const newName = prompt(this._langSvc.instant('Inserisci il nuovo nome:'), savedTrack.properties.name);
+    const newName = prompt(`${this._langSvc.instant('Inserisci il nuovo nome')}:`, savedTrack?.properties?.name);
     if (newName) {
       savedTrack.properties.name = newName;
       this.saveCustomTrack();
@@ -148,14 +148,14 @@ export class DrawTrackComponent {
             from(this._deviceSvc.getInfo()).pipe(
               map(device => {
                 const feature: WmFeature<LineString> = this.track$.value;
-                let drawTrakproperties = feature.properties;
+                const drawTrackProperties = feature?.properties;
 
                 const properties = {
-                  drawTrackProperties: drawTrakproperties,
                   name: this.fg.value.title,
                   form: this.fg.value,
                   uuid: generateUUID(),
                   app_id: `${geohubId}`,
+                  drawTrackProperties,
                   device,
                 };
 
@@ -170,7 +170,7 @@ export class DrawTrackComponent {
             this.reloadEvt.emit();
             return this._alertCtrl
               .create({
-                message: this._langSvc.instant('Il percorso è stato salvato correttamente!'),
+                message: `${this._langSvc.instant('Il percorso è stato salvato correttamente')}!`,
                 buttons: ['OK'],
               })
           }),
@@ -178,8 +178,8 @@ export class DrawTrackComponent {
           catchError(_ => {
             this._alertCtrl
               .create({
-                header: 'Errore',
-                message: this._langSvc.instant('Si è verificato un errore durante il salvataggio del percorso. Riprova!'),
+                header: this._langSvc.instant('Errore'),
+                message: `${this._langSvc.instant('Si è verificato un errore durante il salvataggio del percorso. Riprova')}!`,
                 buttons: ['OK'],
               })
               .then(alert => alert.present());
@@ -196,7 +196,7 @@ export class DrawTrackComponent {
       if (!this.track$.value.properties.name || this.track$.value.properties.name.trim() === '') {
         while (this.track$.value.properties.name == '') {
           this.track$.value.properties.name = prompt(
-            this._langSvc.instant('Per favore, inserisci un nome per il percorso.'),
+            `${this._langSvc.instant('Per favore, inserisci un nome per il percorso')}.`,
           );
         }
       }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -69,9 +69,10 @@
   "Collegamenti esterni": "Externe Links",
   "Filtri": "Filter",
   "where": "Orte",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Leider gibt es keine Ergebnisse mit diesen Suchkriterien",
-  "Inserisci il nuovo nome:": "Bitte geben Sie einen Namen ein:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "An error occurred while saving the track. Try again!",
-  "Il percorso è stato salvato correttamente!": "The track has been saved correctly!",
-  "Per favore, inserisci un nome per il percorso.": "Please insert a name for the track."
+  "Spiacenti non ci sono risultati con questi criteri di ricerca": "Leider gibt es keine Ergebnisse mit diesen Suchkriterien",
+  "Inserisci il nuovo nome": "Bitte geben Sie einen Namen ein",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "Beim Speichern der Strecke ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut",
+  "Il percorso è stato salvato correttamente": "Die Strecke wurde erfolgreich gespeichert",
+  "Per favore, inserisci un nome per il percorso": "Bitte geben Sie einen Namen für die Strecke ein",
+  "Errore": "Fehler"
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -69,5 +69,9 @@
   "Collegamenti esterni": "Externe Links",
   "Filtri": "Filter",
   "where": "Orte",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Leider gibt es keine Ergebnisse mit diesen Suchkriterien"
+  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Leider gibt es keine Ergebnisse mit diesen Suchkriterien",
+  "Inserisci il nuovo nome:": "Bitte geben Sie einen Namen ein:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "An error occurred while saving the track. Try again!",
+  "Il percorso è stato salvato correttamente!": "The track has been saved correctly!",
+  "Per favore, inserisci un nome per il percorso.": "Please insert a name for the track."
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -69,5 +69,9 @@
   "Collegamenti esterni": "External links",
   "Filtri": "Filters",
   "where": "Places",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Sorry, there are no results with these search criteria"
+  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Sorry, there are no results with these search criteria",
+  "Inserisci il nuovo nome:": "Insert the new name:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "An error occurred while saving the track. Try again!",
+  "Il percorso è stato salvato correttamente!": "The track has been saved correctly!",
+  "Per favore, inserisci un nome per il percorso.": "Please insert a name for the track."
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -69,9 +69,10 @@
   "Collegamenti esterni": "External links",
   "Filtri": "Filters",
   "where": "Places",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Sorry, there are no results with these search criteria",
-  "Inserisci il nuovo nome:": "Insert the new name:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "An error occurred while saving the track. Try again!",
-  "Il percorso è stato salvato correttamente!": "The track has been saved correctly!",
-  "Per favore, inserisci un nome per il percorso.": "Please insert a name for the track."
+  "Spiacenti non ci sono risultati con questi criteri di ricerca": "Sorry, there are no results with these search criteria",
+  "Inserisci il nuovo nome": "Insert the new name",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "An error occurred while saving the track. Try again",
+  "Il percorso è stato salvato correttamente": "The track has been saved correctly",
+  "Per favore, inserisci un nome per il percorso": "Please insert a name for the track",
+  "Errore": "Error"
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -69,5 +69,9 @@
   "Collegamenti esterni": "Enlaces externos",
   "Filtri": "Filtros",
   "where": "Lugares",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Lo sentimos, no hay resultados con estos criterios de búsqueda"
+  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Lo sentimos, no hay resultados con estos criterios de búsqueda",
+  "Inserisci il nuovo nome:": "Introduce el nuevo nombre:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Se ha producido un error al guardar el track. Inténtalo de nuevo!",
+  "Il percorso è stato salvato correttamente!": "El track se ha guardado correctamente!",
+  "Per favore, inserisci un nome per el track.": "Por favor, introduce un nombre para el track."
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -69,9 +69,10 @@
   "Collegamenti esterni": "Enlaces externos",
   "Filtri": "Filtros",
   "where": "Lugares",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Lo sentimos, no hay resultados con estos criterios de búsqueda",
-  "Inserisci il nuovo nome:": "Introduce el nuevo nombre:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Se ha producido un error al guardar el track. Inténtalo de nuevo!",
-  "Il percorso è stato salvato correttamente!": "El track se ha guardado correctamente!",
-  "Per favore, inserisci un nome per el track.": "Por favor, introduce un nombre para el track."
+  "Spiacenti non ci sono risultati con questi criteri di ricerca": "Lo sentimos, no hay resultados con estos criterios de búsqueda",
+  "Inserisci il nuovo nome": "Introduce el nuevo nombre",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "Se ha producido un error al guardar el track. Inténtalo de nuevo",
+  "Il percorso è stato salvato correttamente": "El track se ha guardado correctamente",
+  "Per favore, inserisci un nome per el track": "Por favor, introduce un nombre para el track",
+  "Errore": "Error"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -69,9 +69,10 @@
   "Collegamenti esterni": "Liens externes",
   "Filtri": "Filtres",
   "where": "Lieux",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Désolé, il n'y a aucun résultat avec ces critères de recherche",
-  "Inserisci il nuovo nome:": "Insérer le nouveau nom:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Une erreur est survenue lors de la sauvegarde du track. Essayez encore!",
-  "Il percorso è stato salvato correttamente!": "Le track a été sauvegardé correctement!",
-  "Per favore, inserisci un nome per el track.": "Veuillez entrer un nom pour le track."
+  "Spiacenti non ci sono risultati con questi criteri di ricerca": "Désolé, il n'y a aucun résultat avec ces critères de recherche",
+  "Inserisci il nuovo nome": "Insérer le nouveau nom",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "Une erreur est survenue lors de la sauvegarde du track. Essayez encore",
+  "Il percorso è stato salvato correttamente": "Le track a été sauvegardé correctement",
+  "Per favore, inserisci un nome per el track": "Veuillez entrer un nom pour le track",
+  "Errore": "Erreur"
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -69,5 +69,9 @@
   "Collegamenti esterni": "Liens externes",
   "Filtri": "Filtres",
   "where": "Lieux",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Désolé, il n'y a aucun résultat avec ces critères de recherche"
+  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Désolé, il n'y a aucun résultat avec ces critères de recherche",
+  "Inserisci il nuovo nome:": "Insérer le nouveau nom:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Une erreur est survenue lors de la sauvegarde du track. Essayez encore!",
+  "Il percorso è stato salvato correttamente!": "Le track a été sauvegardé correctement!",
+  "Per favore, inserisci un nome per el track.": "Veuillez entrer un nom pour le track."
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -64,5 +64,9 @@
   "running": "Corsa",
   "cycling": "In bicicletta",
   "poi_type": "Punti di interesse",
-  "where": "Luoghi"
+  "where": "Luoghi",
+  "Inserisci il nuovo nome:": "Inserisci il nuovo nome:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Si è verificato un errore durante il salvataggio del percorso. Riprova!",
+  "Il percorso è stato salvato correttamente!": "Il percorso è stato salvato correttamente!",
+  "Per favore, inserisci un nome per il percorso.": "Per favore, inserisci un nome per il percorso."
 }

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -65,8 +65,9 @@
   "cycling": "In bicicletta",
   "poi_type": "Punti di interesse",
   "where": "Luoghi",
-  "Inserisci il nuovo nome:": "Inserisci il nuovo nome:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Si è verificato un errore durante il salvataggio del percorso. Riprova!",
-  "Il percorso è stato salvato correttamente!": "Il percorso è stato salvato correttamente!",
-  "Per favore, inserisci un nome per il percorso.": "Per favore, inserisci un nome per il percorso."
+  "Inserisci il nuovo nome": "Inserisci il nuovo nome",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "Si è verificato un errore durante il salvataggio del percorso. Riprova",
+  "Il percorso è stato salvato correttamente": "Il percorso è stato salvato correttamente",
+  "Per favore, inserisci un nome per il percorso": "Per favore, inserisci un nome per il percorso",
+  "Errore": "Errore"
 }

--- a/src/assets/i18n/pr.json
+++ b/src/assets/i18n/pr.json
@@ -69,5 +69,9 @@
   "Collegamenti esterni": "Links externos",
   "Filtri": "Filtros",
   "where": "Locais",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Desculpe, não há resultados com estes critérios de pesquisa"
+  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Desculpe, não há resultados com estes critérios de pesquisa",
+  "Inserisci il nuovo nome:": "Insira o novo nome:",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Ocorreu um erro ao salvar o track. Tente novamente!",
+  "Il percorso è stato salvato correttamente!": "O track foi salvo corretamente!",
+  "Per favore, inserisci un nome per el track.": "Por favor, insira um nome para o track."
 }

--- a/src/assets/i18n/pr.json
+++ b/src/assets/i18n/pr.json
@@ -69,9 +69,10 @@
   "Collegamenti esterni": "Links externos",
   "Filtri": "Filtros",
   "where": "Locais",
-  "Spiacenti non ci sono risultati con questi criteri di ricerca.": "Desculpe, não há resultados com estes critérios de pesquisa",
-  "Inserisci il nuovo nome:": "Insira o novo nome:",
-  "Si è verificato un errore durante il salvataggio del percorso. Riprova!": "Ocorreu um erro ao salvar o track. Tente novamente!",
-  "Il percorso è stato salvato correttamente!": "O track foi salvo corretamente!",
-  "Per favore, inserisci un nome per el track.": "Por favor, insira um nome para o track."
+  "Spiacenti non ci sono risultati con questi criteri di ricerca": "Desculpe, não há resultados com estes critérios de pesquisa",
+  "Inserisci il nuovo nome": "Insira o novo nome",
+  "Si è verificato un errore durante il salvataggio del percorso. Riprova": "Ocorreu um erro ao salvar o track. Tente novamente",
+  "Il percorso è stato salvato correttamente": "O track foi salvo corretamente",
+  "Per favore, inserisci un nome per el track": "Por favor, insira um nome para o track",
+  "Errore": "Erro"
 }


### PR DESCRIPTION
- Updated the import statement in `draw-track.component.ts` to include the `EMPTY` operator from `rxjs`.
- Added a new import statement for `syncUgcTracks` from `ugc.actions`.
- Added a new import statement for `LangService` from `lang.service`.
- Modified the prompt message in the `editCustomTrackName` method to use a translated string.
- Modified the prompt message in the saveCustomTrack method to use a translated string.
- Added an alert message after successfully saving a track, using a translated string.
- Added an error alert message when there is an error saving a track, using a translated string.

Updated translations:
- German translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per il percorso.".

- English translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per il percorso.".

- Spanish translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per il track.".

- French translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per el track.".

- Italian translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per il percorso.".

- Portuguese translation
  - Added translations for "Inserisci il nuovo nome:", "Si è verificato un errore durante il salvataggio del percorso. Riprova!", and "Il percorso è stato salvato correttamente!".
  - Updated translation for "Per favore, inserisci un nome per el track.".
