### PR TITLE
chore: Update map.page.ts oc: 4476

### DIFF
--- a/src/app/pages/map/map.page.ts
+++ b/src/app/pages/map/map.page.ts
@@ -1,9 +1,9 @@
 import {currentEcTrackId, loadEcPois} from '@wm-core/store/features/ec/ec.actions';
 import {
   countSelectedFilters,
-  allEcPois,
   ecPois,
   currentEcTrack,
+  allEcpoiFeatures,
 } from '@wm-core/store/features/ec/ec.selector';
 import {
   ChangeDetectionStrategy,
@@ -293,7 +293,7 @@ export class MapPage implements OnDestroy {
       }),
     );
     this.setCurrentPoiSub$ = this._store
-      .select(allEcPois)
+      .select(allEcpoiFeatures)
       .pipe(
         filter(p => p != null),
         tap(() => this._loadingSvc.close('Loading pois...')),


### PR DESCRIPTION
- Renamed the imported variable `allEcPois` to `allEcpoiFeatures`
- Updated the usage of `allEcPois` to use `allEcpoiFeatures` in the code
chore: Update map.page.ts

- Renamed the imported variable `allEcPois` to `allEcpoiFeatures`
- Updated the usage of `allEcPois` to use `allEcpoiFeatures` in the code
