### PR TITLE
chore: Update map page with geohub editing feature oc: 4678

### DIFF
--- a/src/app/pages/map/map.page.html
+++ b/src/app/pages/map/map.page.html
@@ -26,6 +26,15 @@
         </ion-label>
       </ion-item>
     </ng-container>
+    <ion-button
+      class="wm-edit-geohub"
+      expand="block"
+      *ngIf="enableEditingInline$|async"
+      (click)="openGeohub()"
+      bottom
+    >
+      {{'edit geohub'|wmtrans}}
+    </ion-button>
   </wm-track-properties>
 
   <wm-ugc-track-properties

--- a/src/app/pages/map/map.page.scss
+++ b/src/app/pages/map/map.page.scss
@@ -114,4 +114,8 @@ webmapp-map-page {
       left: 400px;
     }
   }
+
+  .wm-edit-geohub {
+    margin-top: 20px;
+  }
 }

--- a/src/app/pages/map/map.page.ts
+++ b/src/app/pages/map/map.page.ts
@@ -4,7 +4,7 @@ import {ChangeDetectionStrategy, Component, ViewChild, ViewEncapsulation} from '
 import {LineString, Point} from 'geojson';
 import {Store} from '@ngrx/store';
 import {BehaviorSubject, Observable} from 'rxjs';
-import {map, tap} from 'rxjs/operators';
+import {map, take, tap} from 'rxjs/operators';
 
 import {
   confAUTHEnable,
@@ -12,6 +12,7 @@ import {
   confLANGUAGES,
   confOPTIONS,
   confShowDrawTrack,
+  confShowEditingInline,
 } from '@wm-core/store/conf/conf.selector';
 
 import {IOPTIONS} from '@wm-core/types/config';
@@ -49,6 +50,7 @@ export class MapPage {
   currentTrack$ = this._store.select(track);
   currentUgcPoiProperties$ = this._store.select(currentUgcPoiProperties);
   ecTrack$: Observable<WmFeature<LineString> | null> = this._store.select(currentEcTrack);
+  enableEditingInline$: Observable<boolean> = this._store.select(confShowEditingInline);
   geohubId$ = this._store.select(confGeohubId);
   langs$ = this._store.select(confLANGUAGES).pipe(
     tap(l => {
@@ -78,6 +80,16 @@ export class MapPage {
   }
 
   next(): void {}
+
+  openGeohub(): void {
+    this.ecTrack$.pipe(take(1)).subscribe(track => {
+      const id = track && track.properties && track.properties.id;
+      if (id != null) {
+        const url = `https://geohub.webmapp.it/resources/ec-tracks/${id}/edit?viaResource&viaResourceId&viaRelationship`;
+        window.open(url, '_blank').focus();
+      }
+    });
+  }
 
   openPopup(popup: any): void {
     this.homeCmp.popup$.next(popup);


### PR DESCRIPTION
- Added an "Edit Geohub" button to the map page HTML
- Updated the map page SCSS to style the "Edit Geohub" button
- Modified the map page TypeScript to handle opening the Geohub editor when the button is clicked
